### PR TITLE
fix: add bifercation for images type in itemAssetType

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@devprotocol/clubs-plugin-passport",
-	"version": "0.1.0-beta.18",
+	"version": "0.1.0-beta.19",
 	"type": "module",
 	"description": "Passport plugin for clubs",
 	"main": "dist/index.js",

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,8 @@ export type PassportItemAssetType =
 	| 'short-video-link'
 	| 'image'
 	| 'image-link'
+	| 'image-playable'
+	| 'image-playable-link'
 	| 'video'
 	| 'video-link'
 	| 'bgm'


### PR DESCRIPTION
• Update itemAssetType to include a bifurcation for images. If the Image is **.gif, .avif, or other playable, the type should be 'image-playable' or 'image-playable-link'**.  Otherwise, it should be 'image' or 'image-link'.

**Reason for the change:**- This way we keep the database concise in the way that images are stored as per their behaviour and that there is no overlap or ambiguity between sub categories of types (for example - static image or dynamic image).